### PR TITLE
fix: fix no template code in .vue file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -174,6 +174,9 @@ async function genTemplateCode(
   ssr: boolean
 ) {
   const template = descriptor.template!
+
+  if (!template) return ''
+
   const hasScoped = descriptor.styles.some((style) => style.scoped)
 
   // If the template is not using pre-processor AND is not using external src,


### PR DESCRIPTION
The .vue file may have no template code.

**min-reproduction: https://stackblitz.com/edit/vitejs-vite-md4vf7?file=src%2Fcomponents%2Ftransition.vue**