### PR TITLE
refactor: limit passable compilerOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,20 @@ export interface Options {
   isProduction?: boolean
 
   // options to pass on to vue/compiler-sfc
-  script?: Partial<SFCScriptCompileOptions>
-  template?: Partial<SFCTemplateCompileOptions>
-  style?: Partial<SFCStyleCompileOptions>
+  script?: Partial<Pick<SFCScriptCompileOptions, 'babelParserPlugins'>>
+  template?: Partial<
+    Pick<
+      SFCTemplateCompileOptions,
+      | 'compiler'
+      | 'compilerOptions'
+      | 'preprocessOptions'
+      | 'transpileOptions'
+      | 'transformAssetUrls'
+      | 'transformAssetUrlsOptions'
+      | 'isTS'
+    >
+  >
+  style?: Partial<Pick<SFCStyleCompileOptions, 'trim'>>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ export interface Options {
       | 'transpileOptions'
       | 'transformAssetUrls'
       | 'transformAssetUrlsOptions'
-      | 'isTS'
     >
   >
   style?: Partial<Pick<SFCStyleCompileOptions, 'trim'>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ export interface Options {
       | 'transpileOptions'
       | 'transformAssetUrls'
       | 'transformAssetUrlsOptions'
-      | 'isTS'
     >
   >
   style?: Partial<Pick<SFCStyleCompileOptions, 'trim'>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,20 @@ export interface Options {
   isProduction?: boolean
 
   // options to pass on to vue/compiler-sfc
-  script?: Partial<SFCScriptCompileOptions>
-  template?: Partial<SFCTemplateCompileOptions>
-  style?: Partial<SFCStyleCompileOptions>
+  script?: Partial<Pick<SFCScriptCompileOptions, 'babelParserPlugins'>>
+  template?: Partial<
+    Pick<
+      SFCTemplateCompileOptions,
+      | 'compiler'
+      | 'compilerOptions'
+      | 'preprocessOptions'
+      | 'transpileOptions'
+      | 'transformAssetUrls'
+      | 'transformAssetUrlsOptions'
+      | 'isTS'
+    >
+  >
+  style?: Partial<Pick<SFCStyleCompileOptions, 'trim'>>
 
   // customElement?: boolean | string | RegExp | (string | RegExp)[]
   // reactivityTransform?: boolean | string | RegExp | (string | RegExp)[]


### PR DESCRIPTION
Same with https://github.com/vitejs/vite/pull/8994.
