### PR TITLE
docs: remove not existing option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ export interface Options {
   include?: string | RegExp | (string | RegExp)[]
   exclude?: string | RegExp | (string | RegExp)[]
 
-  ssr?: boolean
   isProduction?: boolean
 
   // options to pass on to vue/compiler-sfc


### PR DESCRIPTION
According to `index.ts`, there is no `ssr` option I think.

https://github.com/vitejs/vite-plugin-vue2/blob/d3d3a599f191bef5d6034993de92e2176e9577b3/src/index.ts#L25-L39