### PR TITLE
bugfix/assetUrlOptions

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -133,8 +133,8 @@ function resolveTemplateCompilerOptions(
     isFunctional: !!block.attrs.functional,
     optimizeSSR: ssr,
     transformAssetUrlsOptions: {
-      ...options.template?.transformAssetUrlsOptions,
-      ...assetUrlOptions
+      ...assetUrlOptions,
+      ...options.template?.transformAssetUrlsOptions
     },
     preprocessLang: block.lang,
     preprocessOptions,


### PR DESCRIPTION
This fixes #47

### Changes:
- Fixed order of loading the assetUrlOptions from the user and defaults, preventing the defaults to override the user settings.

---

### Note:

I could not find anything on "how-to-commit" or house-rules of how a PR is supposed to be made. Also running the `ppm changeling` command added things I did not change myself, so I (for now) did not add this in my commit and PR.

Test have been run, all of them passed (1 test file, 18 tests in total). I've also tried the previously failing production build (that requires the `includeAbsolute` to be false), which also successfully compiles and loads in the browser where it previously gave a TypeError on loading some assets that weren't JavaScript files.

If I need to change anything to comply with the standards in this repo, please drop a comment and I'll happily oblige. Please let me know what I can do.