### PR TITLE
fix: update functional components in hmr.reload()

### DIFF
--- a/src/utils/hmrRuntime.ts
+++ b/src/utils/hmrRuntime.ts
@@ -185,7 +185,8 @@ __VUE_HMR_RUNTIME__.reload = tryWrap(function (id, options) {
     }
   }
   record.instances.slice().forEach(function (instance) {
-    if (instance.$vnode && instance.$vnode.context) {
+    if (record.options.functional) instance.$forceUpdate()
+    else if (instance.$vnode && instance.$vnode.context) {
       instance.$vnode.context.$forceUpdate()
     } else {
       console.warn(


### PR DESCRIPTION
An SFC functional component that does not use `<template functional>` will go through `__VUE_HMR_RUNTIME__.reload()` instead of `.rerender()`, because the plugin can't detect the [`functional template attr`](https://github.com/vitejs/vite-plugin-vue2/blob/main/src/main.ts#L43-L44) to inject its [`_rerender_only` marker](https://github.com/vitejs/vite-plugin-vue2/blob/main/src/main.ts#L114-L119).

After updating the component's options, the reload function will still try to reload it by updating its parent via `$vnode.context`. This causes two issues:

1. For functional components, the `instance` already points to the component's (stateful) parent. In turn, the functional component's *grandparent* is updated, which does not cause the functional component down the tree to rerender. (unless props changed) So the update does not appear on the screen until maybe later some other condition causes a rerender:

```
A (instance.$vnode.context)
  B (instance)
    C (functional component child)

reload(C) ----> A.$forceUpdate() --/XX/--> C rerenders
```

2. If the functional component is rendered as child in the root component, then even though not the root but a child was modified, `instance` will point to the root. The runtime notices that the instance has no parent context (which would be the child's grandparent) and issues a warning about unsupported root HMR instead of updating the child:

```
A (undefined)
  App.vue (root)
    C (functional component child)

reload(C) ----> (undefined).$forceUpdate() ----> warning --/XX/--> C rerenders
```

To fix this, this PR makes `__VUE_HMR_RUNTIME__.reload` call `.$forceUpdate()` on the instance itself instead of on the parent context if the reloaded component is functional.