### PR TITLE
feat: ignore empty style when compiler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ export async function transformMain(
 
   // feature information
   const hasScoped = descriptor.styles.some(s => s.scoped)
-  const hasCssModules = descriptor.styles.some(s => s.module)
+  const hasCssModules = descriptor.styles.some(s => s.module && !!s.content && !!s.content.trim())
   const hasFunctional =
     descriptor.template && descriptor.template.attrs.functional
 
@@ -279,6 +279,7 @@ async function genStyleCode(
   if (descriptor.styles.length) {
     for (let i = 0; i < descriptor.styles.length; i++) {
       const style = descriptor.styles[i]
+      if (!style.src && (!style.content || !style.content.trim())) continue
       if (style.src) {
         await linkSrcToDescriptor(
           style.src,

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -108,6 +108,17 @@ export function declareTests(isBuild: boolean) {
     }
   })
 
+  test('SFC empty style', async() => {
+    const el = await page.$$eval('style', (elements) => {
+      return elements.map((e) => {
+        return e.innerHTML?.trim()
+      }).filter((e) => {
+        return !e
+      })
+    })
+    expect(el).toHaveLength(0)
+  })
+
   test('SFC <custom>', async () => {
     expect(await getText('.custom-block')).toMatch('Custom Block')
     expect(await getText('.custom-block-lang')).toMatch('Custom Block')


### PR DESCRIPTION
Prevents generation of empty style file when use 
```
<styles scope></style>
<styles module></style>
```