### PR TITLE
feat: allow custom normalizer id

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ export interface Options {
   include?: string | RegExp | (string | RegExp)[]
   exclude?: string | RegExp | (string | RegExp)[]
 
+  normalizerId?: string
   isProduction?: boolean
 
   // options to pass on to vue/compiler-sfc

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export interface Options {
   include?: string | RegExp | (string | RegExp)[]
   exclude?: string | RegExp | (string | RegExp)[]
 
+  normalizerId?: string
   isProduction?: boolean
 
   // options to pass on to vue/compiler-sfc
@@ -50,6 +51,7 @@ export interface Options {
 
 export interface ResolvedOptions extends Options {
   compiler: typeof _compiler
+  normalizerId: string
   root: string
   sourceMap: boolean
   cssDevSourcemap: boolean
@@ -60,7 +62,8 @@ export interface ResolvedOptions extends Options {
 export default function vuePlugin(rawOptions: Options = {}): Plugin {
   const {
     include = /\.vue$/,
-    exclude
+    exclude,
+    normalizerId = NORMALIZER_ID
     // customElement = /\.ce\.vue$/,
     // reactivityTransform = false
   } = rawOptions
@@ -73,6 +76,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     ...rawOptions,
     include,
     exclude,
+    normalizerId,
     // customElement,
     // reactivityTransform,
     root: process.cwd(),
@@ -118,7 +122,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
 
     async resolveId(id) {
       // component export helper
-      if (id === NORMALIZER_ID || id === HMR_RUNTIME_ID) {
+      if (id === normalizerId || id === HMR_RUNTIME_ID) {
         return id
       }
       // serve sub-part requests (*?vue) as virtual modules
@@ -129,7 +133,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
 
     load(id, opt) {
       const ssr = opt?.ssr === true
-      if (id === NORMALIZER_ID) {
+      if (id === normalizerId) {
         return normalizerCode
       }
       if (id === HMR_RUNTIME_ID) {
@@ -185,7 +189,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
 
       if (!query.vue) {
         // main request
-        return transformMain(code, filename, options, this, ssr)
+        return transformMain(code, filename, options, this, ssr, normalizerId)
       } else {
         // sub block request
         const descriptor = query.src

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { transformTemplateInMain } from './template'
 import { isOnlyTemplateChanged } from './handleHotUpdate'
 import { createRollupError } from './utils/error'
 import type { ResolvedOptions } from '.'
-import { NORMALIZER_ID } from './utils/componentNormalizer'
 import { HMR_RUNTIME_ID } from './utils/hmrRuntime'
 
 export async function transformMain(
@@ -21,7 +20,8 @@ export async function transformMain(
   filename: string,
   options: ResolvedOptions,
   pluginContext: TransformPluginContext,
-  ssr: boolean
+  ssr: boolean,
+  normalizerId: string
   // asCustomElement: boolean
 ) {
   const { devServer, isProduction, devToolsEnabled } = options
@@ -74,7 +74,7 @@ export async function transformMain(
 
   output.push(
     `/* normalize component */
-import __normalizer from "${NORMALIZER_ID}"
+import __normalizer from "${normalizerId}"
 var __component__ = /*#__PURE__*/__normalizer(
   _sfc_main,
   _sfc_render,


### PR DESCRIPTION
Allow the normalizer identifier to be changed via the plugin options. This helps resolve a particular use case with AEM (Adobe Experience Manager) whereby its internal namespace validator incorrectly identifies `_plugin-vue2:normalizer` as an XML namespace.

The default behaviour will continue to use the existing behaviour while enabling developers to customise what this identifier is during builds.