### PR TITLE
feat: resolve complier from peer dep when unable to resolve from the root

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -10,7 +10,7 @@ import type * as _compiler from 'vue/compiler-sfc'
 
 export function resolveCompiler(root: string): typeof _compiler {
   // resolve from project root first, then fallback to peer dep (if any)
-  const compiler = tryRequire('vue/compiler-sfc', root)
+  const compiler = tryRequire('vue/compiler-sfc', root) || tryRequire('vue/compiler-sfc')
 
   if (!compiler) {
     throw new Error(


### PR DESCRIPTION
── root
&ensp;&ensp;└── v2-7
&ensp;&ensp;&ensp;&ensp;└──  node_modules
&ensp;&ensp;&ensp;&ensp;└──  vite.config.ts
&ensp;&ensp;&ensp;&ensp;└── ...
&ensp;&ensp;└── src
&ensp;&ensp;&ensp;&ensp;└── index.ts


Hello, when I excute `vite build --config v2-7/vite.config.ts` in root. There is no vue(2.7)，but the v2-7 has. And I ran into this error：
> [vite:vue2] Failed to resolve vue/compiler-sfc.
@vitejs/plugin-vue2 requires vue (>=2.7.0) to be present in the dependency tree.
error during build:
Error: Failed to resolve vue/compiler-sfc.
@vitejs/plugin-vue2 requires vue (>=2.7.0) to be present in the dependency tree.


I don't know why remove [this part of the code](https://github.com/vitejs/vite-plugin-vue2/commit/893cbf6ae1e01e39bcf90405bcaa7707b1550564#diff-041bb58b49fbc5e7fdf9b8d09f0f0ae8d524d727947bcfa3e3d1c91b8a35aeeeR13).I think this may be a mistake. It should be the same as [ @vitejs/plugin-vue](https://github.com/vitejs/vite/blob/main/packages/plugin-vue/src/compiler.ts#L14)
