### PR TITLE
feat: Update for Vite 4.x support, closes @vitejs/plugin-vue2#71

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-vue2/#readme",
   "peerDependencies": {
-    "vite": "^3.0.0",
+    "vite": "^3.0.0 || ^4.0.0",
     "vue": "^2.7.0-0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

With Vite 4's released, this PR updates the `peerDependencies` to allow it to work with Vite 4.x (assuming no other changes are needed).

### Linked Issues

Closes: https://github.com/vitejs/vite-plugin-vue2/issues/71

### Additional context
