### PR TITLE
fix(hmr): should reload if relies file changed after re-render

### DIFF
--- a/playground/hmr/TestHmr.vue
+++ b/playground/hmr/TestHmr.vue
@@ -1,8 +1,10 @@
 <script>
+import { test } from './lib.js'
 export default {
   data() {
     return {
       count: 0,
+      number: test()
     }
   },
 }
@@ -20,5 +22,6 @@ export default {
         &gt;&gt;&gt; {{ count }} &lt;&lt;&lt;
       </button>
     </p>
+    <span class="hmr-number">{{ number }}</span>
   </div>
 </template>

--- a/playground/hmr/lib.js
+++ b/playground/hmr/lib.js
@@ -1,0 +1,3 @@
+export function test() {
+  return 100
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { createFilter } from 'vite'
+import { createFilter, normalizePath } from 'vite'
 import type { Plugin, ViteDevServer } from 'vite'
 import type {
   SFCBlock,
@@ -85,6 +85,12 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     name: 'vite:vue2',
 
     handleHotUpdate(ctx) {
+      ctx.server.ws.send({
+        type: 'custom',
+        event: 'file-changed',
+        data: { file: normalizePath(ctx.file) },
+      })
+
       if (!filter(ctx.file)) {
         return
       }

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -80,6 +80,14 @@ export function declareTests(isBuild: boolean) {
       )
       await expectByPolling(() => getText('.hmr-increment'), 'count is 1337')
     })
+
+    test('should reload when relies file changed', async () => {
+      await expectByPolling(() => getText('.hmr-number'), '100')
+      await updateFile('hmr/lib.js', content =>
+        content.replace('100', '200')
+      )
+      await expectByPolling(() => getText('.hmr-number'), '200')
+    })
   }
 
   test('SFC <style scoped>', async () => {


### PR DESCRIPTION
### Bug Fixes
热更新失效 ([#7](https://github.com/vitejs/vite-plugin-vue/issues/7))

fix(hmr): should reload if relies file changed after re-render ([#471](https://github.com/vitejs/vite-plugin-vue/pull/471))

Fix description: The bugs in vite-plugin-vue also occur in vite-plugin-vue2, and the same solution can be used to fix them.
