### PR TITLE
feat: Allow Vite 7.x.x releases as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-vue2/#readme",
   "peerDependencies": {
-    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "vue": "^2.7.0-0"
   },
   "devDependencies": {


### PR DESCRIPTION
Mirroring the one-line change from https://github.com/vitejs/vite-plugin-vue2/pull/72, https://github.com/vitejs/vite-plugin-vue2/pull/94, and https://github.com/vitejs/vite-plugin-vue2/pull/104 with these changes.

In limited testing, I'm not encountering any issues when forcing vite-plugin-vue2 `v2.3.3` to use Vite `v7.0.0` as a peer dependency. As long as there aren't any immediate concerns regarding Vite 7 compatibility, it would be appreciated if this change could be included in a forthcoming vite-plugin-vue2 release for all of us folks still stuck with projects using Vue 2 😅